### PR TITLE
sgefix

### DIFF
--- a/pass_env
+++ b/pass_env
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #PASS_PREFIX is a list of variable prefixes that should be passed to launcher tasks on remote hosts
-PASS_PREFIX="LAUNCHER TACC ICC GCC LMOD MV2 IMPI PATH LD_LIBRARY_PATH OMP KMP MIC"
+PASS_PREFIX="LAUNCHER TACC ICC GCC LMOD MV2 IMPI PATH LD_LIBRARY_PATH OMP KMP MIC PYTHON"
 
 GREP_ARGS=`
   for prefix in $PASS_PREFIX

--- a/plugins/SGE.rmi
+++ b/plugins/SGE.rmi
@@ -4,6 +4,11 @@
 export LAUNCHER_RMI_HOSTFILE=`mktemp -t launcher.$JOB_ID.hostlist.XXXXXXXX`
 
 #Populate the hostfile
+#Some systems use capital letters.
+if [ -f "$PE_HOSTFILE" ] && [ ! -f "$pe_hostfile" ]; then
+   pe_hostfile=$PE_HOSTFILE
+fi
+
 for i in `cat $pe_hostfile | cut -f 1 -d ' '`
 do
   echo $i >> $LAUNCHER_RMI_HOSTFILE


### PR DESCRIPTION
Two small proposed changes here:

1) support $PE_HOSTFILE in capital letters as well as lowercase.  Lonestar 4 used capital letters.
2) add PYTHONPATH and PYTHONHOME to pass_env (I just put PYTHON to catch both).
