### PR TITLE
[ENH] Use LAUNCHER_NETCAT_FLAGS to add -d in cray systems

### DIFF
--- a/launcher
+++ b/launcher
@@ -12,6 +12,8 @@
 # The University of Texas at Austin
 #------------------------------------------------
 
+NETCAT_CMD="nc ${LAUNCHER_NETCAT_FLAGS}"
+
 if [ "x$LAUNCHER_JOB_FILE" == "x" ]
 then
   if [ "$LAUNCHER_ON_PHI" == "1" ];then
@@ -68,7 +70,7 @@ elif [ $LAUNCHER_SCHED == "block" ]; then
   nextblock=`expr \( $LAUNCHER_TSK_ID + 1 \) \* $blocks + 1`
 else
   # Grab the JID to run from The Count
-  export LAUNCHER_JID=`nc $LAUNCHER_DYN_SRV`
+  export LAUNCHER_JID=`$NETCAT_CMD $LAUNCHER_DYN_SRV`
 fi 
 
 COMPLETE="false"
@@ -100,7 +102,7 @@ while [ $COMPLETE == "false" ]; do
     RETRY=0
     while [ $RETRY -lt 3 ]
     do
-      export LAUNCHER_JID=`nc $LAUNCHER_DYN_SRV`
+      export LAUNCHER_JID=`$NETCAT_CMD $LAUNCHER_DYN_SRV`
       if [ "x$LAUNCHER_JID" == "x" ]
       then
         if [ $RETRY -lt 3 ]


### PR DESCRIPTION
This patch will run the regular ```nc``` command (without ```-d```) if the variable is not set. The ```$LAUNCHER_NETCAT_FLAGS``` can be exported at module load:

```
-- Use -d (cray-specific) in nc command only in LS5
if string.match(os.getenv("TACC_SYSTEM"), "ls5") then
	setenv("LAUNCHER_NETCAT_FLAGS", "-d")
end
```
