### PR TITLE
Support for Python 3

### DIFF
--- a/paramrun
+++ b/paramrun
@@ -141,7 +141,7 @@ if [ "$LAUNCHER_SCHED" == "dynamic" ]; then
     sleep 1s
     if ! ps -p $! >/dev/null 2>/dev/null
     then
-      if [ $RETRY -ne 3 ]
+      if [ $RETRY -ne 10 ]
       then
         echo "WARNING: Unable to start dynamic task service. Retrying..."
         RETRY=`expr $RETRY + 1`

--- a/tskserver
+++ b/tskserver
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 
-import SocketServer
+try:
+  import socketserver
+except ImportError:
+  import SocketServer as socketserver
+
 import sys
 
 (major, minor)=sys.version_info[:2]
 if major<=2 and minor < 7:
-  print "ERROR: Python version 2.7 or better required"
+  print("ERROR: Python version 2.7 or better required")
   sys.exit(1)
 
 num=1
@@ -18,9 +22,9 @@ class TCPIntHandler(SocketServer.BaseRequestHandler):
     global server
     global maxnum
     if num > maxnum:
-      self.request.sendall("Done")
+      self.request.sendall(bytes("Done", "utf-8"))
     else:
-      self.request.sendall("{}".format(num))
+      self.request.sendall(bytes(str(num), "utf-8"))
       num+=1
 
 server = SocketServer.TCPServer((sys.argv[2], port), TCPIntHandler)

--- a/tskserver
+++ b/tskserver
@@ -1,9 +1,18 @@
 #!/usr/bin/env python
 
 try:
-  import socketserver
+  import socketserver as SocketServer
+
+  def prepare_str(s):
+    # convert str s to bytes when using Python 3
+    return bytes(s, "utf-8")
+
 except ImportError:
-  import SocketServer as socketserver
+  import SocketServer
+
+  def prepare_str(s):
+    # no conversion required when using Python 2
+    return s
 
 import sys
 
@@ -22,9 +31,9 @@ class TCPIntHandler(SocketServer.BaseRequestHandler):
     global server
     global maxnum
     if num > maxnum:
-      self.request.sendall(bytes("Done", "utf-8"))
+      self.request.sendall(prepare_str("Done"))
     else:
-      self.request.sendall(bytes(str(num), "utf-8"))
+      self.request.sendall(prepare_str(str(num)))
       num+=1
 
 server = SocketServer.TCPServer((sys.argv[2], port), TCPIntHandler)


### PR DESCRIPTION
I have added code to tskserver to allow it to run in Python 2 and Python 3 interpreters. This is important for me because all my Python development is for Python 3 and it simplifies my job scripts to work with just one interpreter. I have tested the Python 2 support using the helloworld example in the repository. I have tested the Python 3 support using my own job scripts.

I also increased the maximum number of tskserver retries in paramrun from 3 to 10 because I had many failures recently at that point. Adding more retries solved the problem for me but is not related to supporting Python 3.