### PR TITLE
Warning timestamps

### DIFF
--- a/paramrun
+++ b/paramrun
@@ -3,15 +3,15 @@
 function lwarn {
   if [ "x$LAUNCHER_LOGFILE" == "x" -o "$LAUNCHER_LOGFILE" == "stderr" ]
   then
-    date +"ERROR (%D %T): $1" >&2
+    date +"$1 (%D %T): $2" >&2
   else
-    date +"ERROR (%D %T): $1" >$LAUNCHER_LOGFILE
+    date +"$1 (%D %T): $2" >>$LAUNCHER_LOGFILE
   fi
 }
 
 if [ -z $LAUNCHER_DIR ]
 then
-  lwarn "Launcher base directory LAUNCHER_DIR not set. Exiting."
+  lwarn ERROR "Launcher base directory LAUNCHER_DIR not set. Exiting."
   exit
 fi
 
@@ -21,10 +21,10 @@ then
   #Check for older WORKDIR
   if [ ! "x$WORKDIR" == "x" ]
   then
-    lwarn "NOTICE: WORKDIR variable has been depricated. Use LAUNCHER_WORKDIR."
+    lwarn NOTICE "WORKDIR variable has been depricated. Use LAUNCHER_WORKDIR."
     export LAUNCHER_WORKDIR=$WORKDIR
   else
-    lwarn "WARNING: LAUNCHER_WORKDIR variable not set. Using current directory."
+    lwarn WARNING "LAUNCHER_WORKDIR variable not set. Using current directory."
     export LAUNCHER_WORKDIR=`pwd`
   fi
 fi
@@ -32,7 +32,7 @@ fi
 #Step 0: Determine if resource manager integration is enabled
 if [ -z $LAUNCHER_PLUGIN_DIR ]
 then
-  lwarn "WARNING: LAUNCHER_PLUGIN_DIR not set. Defaulting to $LAUNCHER_DIR/plugins."
+  lwarn WARNING "LAUNCHER_PLUGIN_DIR not set. Defaulting to $LAUNCHER_DIR/plugins."
   LAUNCHER_PLUGIN_DIR=$LAUNCHER_DIR/plugins
 fi
 
@@ -45,26 +45,26 @@ else
     source $LAUNCHER_PLUGIN_DIR/$LAUNCHER_RMI.rmi
     export LAUNCHER_HOSTFILE=$LAUNCHER_RMI_HOSTFILE
   else
-    lwarn "WARNING: Resource Manager Integration plugin file $LAUNCHER_RMI.rmi no found."
-    lwarn "         Available options:"
+    lwarn WARNING "Resource Manager Integration plugin file $LAUNCHER_RMI.rmi no found."
+    lwarn "" "         Available options:"
     for rmi in `ls $LAUNCHER_PLUGIN_DIR/*.rmi 2>/dev/null` 
     do
-      lwarn "           `basename $rmi .rmi`"
+      lwarn "" "           `basename $rmi .rmi`"
     done
-    lwarn "         Defaulting to no integration."
+    lwarn "" "         Defaulting to no integration."
   fi
 fi
 
 #Step 1: Ensure that LAUNCHER_HOSTFILE is set and valid
 if [ -z $LAUNCHER_HOSTFILE ]
 then
-  lwarn "WARNING: LAUNCHER_HOSTFILE is not set. Defaulting to localhost."
+  lwarn WARNING "LAUNCHER_HOSTFILE is not set. Defaulting to localhost."
   LAUNCHER_LOCALHOST=1
   export LAUNCHER_NHOSTS=1
 else
   if [ ! -f $LAUNCHER_HOSTFILE ]
   then
-    lwarn "Hostfile ($LAUNCHER_HOSTFILE) not found."
+    lwarn ERROR "Hostfile ($LAUNCHER_HOSTFILE) not found."
     exit
   fi
 fi
@@ -76,7 +76,7 @@ then
   then
     export LAUNCHER_PPN=$LAUNCHER_RMI_PPN
   else
-    lwarn "WARNING: LAUNCHER_PPN is not set. Defaulting to 1."
+    lwarn WARNING "LAUNCHER_PPN is not set. Defaulting to 1."
     export LAUNCHER_PPN=1
   fi
 fi
@@ -87,7 +87,7 @@ then
   then
     export LAUNCHER_NHOSTS=$LAUNCHER_RMI_NHOSTS
   else
-    lwarn "WARNING: LAUNCHER_NHOSTS is not set. Calculating from hostfile."
+    lwarn WARNING "LAUNCHER_NHOSTS is not set. Calculating from hostfile."
     export LAUNCHER_NHOSTS=`wc -l $LAUNCHER_HOSTFILE | awk '{print $1}'`
   fi
 fi
@@ -96,28 +96,28 @@ export LAUNCHER_NPROCS=`expr $LAUNCHER_NHOSTS \* $LAUNCHER_PPN`
 
 if [ -z $LAUNCHER_NPROCS ]
 then
-  lwarn "LAUNCHER_NPROCS is not set."
+  lwarn ERROR "LAUNCHER_NPROCS is not set."
   exit
 fi
 
 #Backward Compatability with v2 and v1: Check for CONTROL_FILE
 if [ ! -z $CONTROL_FILE ]
 then
-  lwarn "NOTICE: CONTROL_FILE variable depricated. Use LAUNCHER_JOB_FILE in the future."
+  lwarn NOTICE "CONTROL_FILE variable depricated. Use LAUNCHER_JOB_FILE in the future."
   export LAUNCHER_JOB_FILE=$CONTROL_FILE
 fi
 
 #Step 3: Ensure that LAUNCHER_JOB_FILE exists
 if [ -z $LAUNCHER_JOB_FILE ]
 then
-  lwarn "WARNING: LAUNCHER_JOB_FILE not set."
+  lwarn WARNING "LAUNCHER_JOB_FILE not set."
   exit
 else
   if [ -f $LAUNCHER_JOB_FILE ]
   then
     export LAUNCHER_NJOBS=`wc -l $LAUNCHER_JOB_FILE | awk '{print $1}'`
   else
-    lwarn "LAUNCHER_JOB_FILE ($LAUNCHER_JOB_FILE) not found."
+    lwarn ERROR "LAUNCHER_JOB_FILE ($LAUNCHER_JOB_FILE) not found."
     exit
   fi
 fi
@@ -151,11 +151,11 @@ if [ "$LAUNCHER_SCHED" == "dynamic" ]; then
     then
       if [ $RETRY -ne 10 ]
       then
-        lwarn "WARNING: Unable to start dynamic task service. Retrying..."
+        lwarn WARNING "Unable to start dynamic task service. Retrying..."
         RETRY=`expr $RETRY + 1`
         sleep 10s
       else 
-        lwarn "Unable to start dynamic task service. Shutting down."
+        lwarn ERROR "Unable to start dynamic task service. Shutting down."
         exit
       fi
     else
@@ -190,7 +190,7 @@ then
     export LAUNCHER_BIND_HT=1
     if [ $LAUNCHER_PPN -gt $num_threads ]
     then
-      lwarn "WARNING: Requested Processes per Node ($LAUNCHER_PPN) exceeds number of available threads ($num_threads). Resetting..."
+      lwarn WARNING "Requested Processes per Node ($LAUNCHER_PPN) exceeds number of available threads ($num_threads). Resetting..."
       export LAUNCHER_PPN=$num_threads
       export LAUNCHER_NPROCS=$(($LAUNCHER_NHOSTS * $LAUNCHER_PPN))
     fi

--- a/paramrun
+++ b/paramrun
@@ -1,19 +1,17 @@
 #!/bin/bash
 
-if [ "x$LAUNCHER_TS" == "x" -o "x$LAUNCHER_TS" == "x0" ]
-then
-  function lwarn {
-    echo $1 >&2
-  }
-else
-  function lwarn {
-    date +"%D %T $1" >&2
-  }
-fi
+function lwarn {
+  if [ "x$LAUNCHER_LOGFILE" == "x" -o "$LAUNCHER_LOGFILE" == "stderr" ]
+  then
+    date +"ERROR (%D %T): $1" >&2
+  else
+    date +"ERROR (%D %T): $1" >$LAUNCHER_LOGFILE
+  fi
+}
 
 if [ -z $LAUNCHER_DIR ]
 then
-  lwarn "ERROR: Launcher base directory LAUNCHER_DIR not set. Exiting."
+  lwarn "Launcher base directory LAUNCHER_DIR not set. Exiting."
   exit
 fi
 
@@ -66,7 +64,7 @@ then
 else
   if [ ! -f $LAUNCHER_HOSTFILE ]
   then
-    lwarn "ERROR: Hostfile ($LAUNCHER_HOSTFILE) not found."
+    lwarn "Hostfile ($LAUNCHER_HOSTFILE) not found."
     exit
   fi
 fi
@@ -98,7 +96,7 @@ export LAUNCHER_NPROCS=`expr $LAUNCHER_NHOSTS \* $LAUNCHER_PPN`
 
 if [ -z $LAUNCHER_NPROCS ]
 then
-  lwarn "ERROR: LAUNCHER_NPROCS is not set."
+  lwarn "LAUNCHER_NPROCS is not set."
   exit
 fi
 
@@ -119,7 +117,7 @@ else
   then
     export LAUNCHER_NJOBS=`wc -l $LAUNCHER_JOB_FILE | awk '{print $1}'`
   else
-    lwarn "ERROR: LAUNCHER_JOB_FILE ($LAUNCHER_JOB_FILE) not found."
+    lwarn "LAUNCHER_JOB_FILE ($LAUNCHER_JOB_FILE) not found."
     exit
   fi
 fi
@@ -157,7 +155,7 @@ if [ "$LAUNCHER_SCHED" == "dynamic" ]; then
         RETRY=`expr $RETRY + 1`
         sleep 10s
       else 
-        lwarn "ERROR: Unable to start dynamic task service. Shutting down."
+        lwarn "Unable to start dynamic task service. Shutting down."
         exit
       fi
     else

--- a/paramrun
+++ b/paramrun
@@ -9,10 +9,20 @@ function lwarn {
   fi
 }
 
+function lexit {
+  if [ "x$LAUNCHER_LOGFILE" == "x" -o "$LAUNCHER_LOGFILE" == "stderr" ]
+  then
+    echo "Launcher exited without completing."
+  else
+    echo "Launcher exited without completing. Please check LAUNCHER_LOGFILE ($LAUNCHER_LOGFILE)."
+  fi
+  exit
+}
+
 if [ -z $LAUNCHER_DIR ]
 then
   lwarn ERROR "Launcher base directory LAUNCHER_DIR not set. Exiting."
-  exit
+  lexit
 fi
 
 
@@ -65,7 +75,7 @@ else
   if [ ! -f $LAUNCHER_HOSTFILE ]
   then
     lwarn ERROR "Hostfile ($LAUNCHER_HOSTFILE) not found."
-    exit
+    lexit
   fi
 fi
 
@@ -97,7 +107,7 @@ export LAUNCHER_NPROCS=`expr $LAUNCHER_NHOSTS \* $LAUNCHER_PPN`
 if [ -z $LAUNCHER_NPROCS ]
 then
   lwarn ERROR "LAUNCHER_NPROCS is not set."
-  exit
+  lexit
 fi
 
 #Backward Compatability with v2 and v1: Check for CONTROL_FILE
@@ -111,14 +121,14 @@ fi
 if [ -z $LAUNCHER_JOB_FILE ]
 then
   lwarn WARNING "LAUNCHER_JOB_FILE not set."
-  exit
+  lexit
 else
   if [ -f $LAUNCHER_JOB_FILE ]
   then
     export LAUNCHER_NJOBS=`wc -l $LAUNCHER_JOB_FILE | awk '{print $1}'`
   else
     lwarn ERROR "LAUNCHER_JOB_FILE ($LAUNCHER_JOB_FILE) not found."
-    exit
+    lexit
   fi
 fi
 
@@ -156,7 +166,7 @@ if [ "$LAUNCHER_SCHED" == "dynamic" ]; then
         sleep 10s
       else 
         lwarn ERROR "Unable to start dynamic task service. Shutting down."
-        exit
+        lexit
       fi
     else
       RUNNING="true"

--- a/paramrun
+++ b/paramrun
@@ -1,9 +1,19 @@
 #!/bin/bash
 
+if [ "x$LAUNCHER_TS" == "x" -o "x$LAUNCHER_TS" == "x0" ]
+then
+  function lwarn {
+    echo $1 >&2
+  }
+else
+  function lwarn {
+    date +"%D %T $1" >&2
+  }
+fi
 
 if [ -z $LAUNCHER_DIR ]
 then
-  echo "ERROR: Launcher base directory LAUNCHER_DIR not set. Exiting." >&2
+  lwarn "ERROR: Launcher base directory LAUNCHER_DIR not set. Exiting."
   exit
 fi
 
@@ -13,10 +23,10 @@ then
   #Check for older WORKDIR
   if [ ! "x$WORKDIR" == "x" ]
   then
-    echo "NOTICE: WORKDIR variable has been depricated. Use LAUNCHER_WORKDIR." >&2
+    lwarn "NOTICE: WORKDIR variable has been depricated. Use LAUNCHER_WORKDIR."
     export LAUNCHER_WORKDIR=$WORKDIR
   else
-    echo "WARNING: LAUNCHER_WORKDIR variable not set. Using current directory." >&2
+    lwarn "WARNING: LAUNCHER_WORKDIR variable not set. Using current directory."
     export LAUNCHER_WORKDIR=`pwd`
   fi
 fi
@@ -24,7 +34,7 @@ fi
 #Step 0: Determine if resource manager integration is enabled
 if [ -z $LAUNCHER_PLUGIN_DIR ]
 then
-  echo "WARNING: LAUNCHER_PLUGIN_DIR not set. Defaulting to $LAUNCHER_DIR/plugins." >&2
+  lwarn "WARNING: LAUNCHER_PLUGIN_DIR not set. Defaulting to $LAUNCHER_DIR/plugins."
   LAUNCHER_PLUGIN_DIR=$LAUNCHER_DIR/plugins
 fi
 
@@ -37,26 +47,26 @@ else
     source $LAUNCHER_PLUGIN_DIR/$LAUNCHER_RMI.rmi
     export LAUNCHER_HOSTFILE=$LAUNCHER_RMI_HOSTFILE
   else
-    echo "WARNING: Resource Manager Integration plugin file $LAUNCHER_RMI.rmi no found." >&2
-    echo "         Available options:" >&2
+    lwarn "WARNING: Resource Manager Integration plugin file $LAUNCHER_RMI.rmi no found."
+    lwarn "         Available options:"
     for rmi in `ls $LAUNCHER_PLUGIN_DIR/*.rmi 2>/dev/null` 
     do
-      echo "           `basename $rmi .rmi`" >&2
+      lwarn "           `basename $rmi .rmi`"
     done
-    echo "         Defaulting to no integration." >&2
+    lwarn "         Defaulting to no integration."
   fi
 fi
 
 #Step 1: Ensure that LAUNCHER_HOSTFILE is set and valid
 if [ -z $LAUNCHER_HOSTFILE ]
 then
-  echo "WARNING: LAUNCHER_HOSTFILE is not set. Defaulting to localhost." >&2
+  lwarn "WARNING: LAUNCHER_HOSTFILE is not set. Defaulting to localhost."
   LAUNCHER_LOCALHOST=1
   export LAUNCHER_NHOSTS=1
 else
   if [ ! -f $LAUNCHER_HOSTFILE ]
   then
-    echo "ERROR: Hostfile ($LAUNCHER_HOSTFILE) not found." >&2
+    lwarn "ERROR: Hostfile ($LAUNCHER_HOSTFILE) not found."
     exit
   fi
 fi
@@ -68,7 +78,7 @@ then
   then
     export LAUNCHER_PPN=$LAUNCHER_RMI_PPN
   else
-    echo "WARNING: LAUNCHER_PPN is not set. Defaulting to 1." >&2
+    lwarn "WARNING: LAUNCHER_PPN is not set. Defaulting to 1."
     export LAUNCHER_PPN=1
   fi
 fi
@@ -79,7 +89,7 @@ then
   then
     export LAUNCHER_NHOSTS=$LAUNCHER_RMI_NHOSTS
   else
-    echo "WARNING: LAUNCHER_NHOSTS is not set. Calculating from hostfile." >&2
+    lwarn "WARNING: LAUNCHER_NHOSTS is not set. Calculating from hostfile."
     export LAUNCHER_NHOSTS=`wc -l $LAUNCHER_HOSTFILE | awk '{print $1}'`
   fi
 fi
@@ -88,28 +98,28 @@ export LAUNCHER_NPROCS=`expr $LAUNCHER_NHOSTS \* $LAUNCHER_PPN`
 
 if [ -z $LAUNCHER_NPROCS ]
 then
-  echo "ERROR: LAUNCHER_NPROCS is not set." >&2
+  lwarn "ERROR: LAUNCHER_NPROCS is not set."
   exit
 fi
 
 #Backward Compatability with v2 and v1: Check for CONTROL_FILE
 if [ ! -z $CONTROL_FILE ]
 then
-  echo "NOTICE: CONTROL_FILE variable depricated. Use LAUNCHER_JOB_FILE in the future." >&2
+  lwarn "NOTICE: CONTROL_FILE variable depricated. Use LAUNCHER_JOB_FILE in the future."
   export LAUNCHER_JOB_FILE=$CONTROL_FILE
 fi
 
 #Step 3: Ensure that LAUNCHER_JOB_FILE exists
 if [ -z $LAUNCHER_JOB_FILE ]
 then
-  echo "WARNING: LAUNCHER_JOB_FILE not set." >&2
+  lwarn "WARNING: LAUNCHER_JOB_FILE not set."
   exit
 else
   if [ -f $LAUNCHER_JOB_FILE ]
   then
     export LAUNCHER_NJOBS=`wc -l $LAUNCHER_JOB_FILE | awk '{print $1}'`
   else
-    echo "ERROR: LAUNCHER_JOB_FILE ($LAUNCHER_JOB_FILE) not found." >&2
+    lwarn "ERROR: LAUNCHER_JOB_FILE ($LAUNCHER_JOB_FILE) not found."
     exit
   fi
 fi
@@ -143,11 +153,11 @@ if [ "$LAUNCHER_SCHED" == "dynamic" ]; then
     then
       if [ $RETRY -ne 10 ]
       then
-        echo "WARNING: Unable to start dynamic task service. Retrying..."
+        lwarn "WARNING: Unable to start dynamic task service. Retrying..."
         RETRY=`expr $RETRY + 1`
         sleep 10s
       else 
-        echo "ERROR: Unable to start dynamic task service. Shutting down."
+        lwarn "ERROR: Unable to start dynamic task service. Shutting down."
         exit
       fi
     else
@@ -182,7 +192,7 @@ then
     export LAUNCHER_BIND_HT=1
     if [ $LAUNCHER_PPN -gt $num_threads ]
     then
-      echo "WARNING: Requested Processes per Node ($LAUNCHER_PPN) exceeds number of available threads ($num_threads). Resetting..."
+      lwarn "WARNING: Requested Processes per Node ($LAUNCHER_PPN) exceeds number of available threads ($num_threads). Resetting..."
       export LAUNCHER_PPN=$num_threads
       export LAUNCHER_NPROCS=$(($LAUNCHER_NHOSTS * $LAUNCHER_PPN))
     fi


### PR DESCRIPTION
All error and warning messages now contain a timestamps. Errors/warnings/notices can now be directed to a file by setting LAUNCHER_LOGFILE. Exit messages now inform user to refer to LAUNCHER_LOGFILE if set.