### PR TITLE
Exclude GNU Screen environmental variables in pass_env

### DIFF
--- a/pass_env
+++ b/pass_env
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+# AJVincelli 3/8/2021: Excluded TERMCAP and its tabbed ($'\t') variables, which causes Launcher to fail when using GNU Screen on some clusters
+
 #EXCLUDE is a list of patterns that should be removed from the environment before passing to launcher tasks on remote hosts
-EXCLUDE="BASH_FUNC ModuleTable LS_ LESS SSH_ PE_MPICH MINICOM SLURM_NODELIST SLURM_JOB_NODELIST PS1 PROMPT_"
+EXCLUDE="BASH_FUNC ModuleTable LS_ LESS SSH_ PE_MPICH MINICOM SLURM_NODELIST SLURM_JOB_NODELIST PS1 PROMPT_ TERMCAP"
 
 GREP_ARGS=`
   for prefix in $EXCLUDE
@@ -10,4 +12,4 @@ GREP_ARGS=`
   done
 `
 
-env | grep -v -e "}$" -e "^ " -e "=$" -e "^_" -e "(" -e ")" $GREP_ARGS | grep -v -e " " | tr '\n' ' '
+env | grep -v -e "}$" -e "^ " -e "=$" -e "^_" -e "(" -e $'\t' $GREP_ARGS | grep -v -e " " | tr '\n' ' '

--- a/pass_env
+++ b/pass_env
@@ -10,4 +10,4 @@ GREP_ARGS=`
   done
 `
 
-env | grep -v -e "}$" -e "^ " -e "=$" -e "^_" -e "(" $GREP_ARGS | grep -v -e " " | tr '\n' ' '
+env | grep -v -e "}$" -e "^ " -e "=$" -e "^_" -e "(" -e ")" $GREP_ARGS | grep -v -e " " | tr '\n' ' '


### PR DESCRIPTION
Exclude ")" from the environment, which causes Launcher to fail when using GNU Screen on some clusters. Excluding the ")" fixes the issue for me.